### PR TITLE
Remove 20.04 tests.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:


### PR DESCRIPTION
GitHub 20.04 runners are deprecated - remove in favour of 24.04.